### PR TITLE
Add explicit Django install step in setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -10,8 +10,9 @@ fi
 # Activate virtual environment
 source venv/bin/activate
 
-# Upgrade pip and install requirements
+# Upgrade pip and install Django and other requirements
 pip install --upgrade pip
+pip install django
 pip install -r requirements.txt
 # Run initial migrations
 


### PR DESCRIPTION
## Summary
- modify `setup.sh` to explicitly install Django before other requirements

## Testing
- `bash setup.sh` *(fails: Could not find a version that satisfies the requirement django)*
- `pytest -q`